### PR TITLE
Add max tls calico 1.24

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -293,6 +293,10 @@ type SecureServingInfo struct {
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	MinTLSVersion uint16
 
+	// MaxTLSVersion optionally overrides the maximum TLS version supported.
+	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+	MaxTLSVersion uint16
+
 	// CipherSuites optionally overrides the list of allowed cipher suites for the server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	CipherSuites []uint16

--- a/pkg/server/options/serving.go
+++ b/pkg/server/options/serving.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"path"
@@ -65,6 +66,9 @@ type SecureServingOptions struct {
 	// MinTLSVersion is the minimum TLS version supported.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
 	MinTLSVersion string
+	// MaxTLSVersion is the maximum TLS version supported.
+	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+	MaxTLSVersion string
 
 	// HTTP2MaxStreamsPerConnection is the limit that the api server imposes on each client.
 	// A value of zero means to use the default provided by golang's HTTP/2 support.
@@ -189,6 +193,10 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"Minimum TLS version supported. "+
 			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
 
+	fs.StringVar(&s.MaxTLSVersion, "tls-max-version", s.MaxTLSVersion,
+		"Maximum TLS version supported. "+
+			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
+
 	fs.Var(cliflag.NewNamedCertKeyArray(&s.SNICertKeys), "tls-sni-cert-key", ""+
 		"A pair of x509 certificate and private key file paths, optionally suffixed with a list of "+
 		"domain patterns which are fully qualified domain names, possibly with prefixed wildcard "+
@@ -283,6 +291,19 @@ func (s *SecureServingOptions) ApplyTo(config **server.SecureServingInfo) error 
 	c.MinTLSVersion, err = cliflag.TLSVersion(s.MinTLSVersion)
 	if err != nil {
 		return err
+	}
+
+	if len(s.MaxTLSVersion) == 0 {
+		c.MaxTLSVersion = tls.VersionTLS13
+	} else {
+		c.MaxTLSVersion, err = cliflag.TLSVersion(s.MaxTLSVersion)
+		if err != nil {
+			return err
+		}
+	}
+
+	if c.MaxTLSVersion < c.MinTLSVersion {
+		return fmt.Errorf("the minimum TLS version must be lower than or equal to the maximum TLS version: %s > %s", s.MinTLSVersion, s.MaxTLSVersion)
 	}
 
 	// load SNI certs

--- a/pkg/server/secure_serving.go
+++ b/pkg/server/secure_serving.go
@@ -60,6 +60,9 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 	if s.MinTLSVersion > 0 {
 		tlsConfig.MinVersion = s.MinTLSVersion
 	}
+	if s.MaxTLSVersion > 0 {
+		tlsConfig.MaxVersion = s.MaxTLSVersion
+	}
 	if len(s.CipherSuites) > 0 {
 		tlsConfig.CipherSuites = s.CipherSuites
 		insecureCiphers := flag.InsecureTLSCiphers()


### PR DESCRIPTION
Cherry pick of https://github.com/projectcalico/kubernetes-apiserver/pull/1 on calico-1.24.

https://github.com/projectcalico/kubernetes-apiserver/pull/1: Add maximum TLS version to the tls.Config